### PR TITLE
Adjust method signatures to match parent

### DIFF
--- a/action.php
+++ b/action.php
@@ -13,7 +13,7 @@ require_once DOKU_PLUGIN.'action.php';
 
 class action_plugin_markdownextra extends DokuWiki_Action_Plugin {
 
-   function register(&$controller) {
+   function register(Doku_Event_Handler $controller) {
       $controller->register_hook('PARSER_WIKITEXT_PREPROCESS',
 'BEFORE', $this, 'handle_parser_wikitext_preprocess');
       $controller->register_hook('TPL_METAHEADER_OUTPUT',

--- a/syntax.php
+++ b/syntax.php
@@ -35,7 +35,7 @@ class syntax_plugin_markdownextra extends DokuWiki_Syntax_Plugin {
         $this->Lexer->addExitPattern('</markdown>', 'plugin_markdownextra');
     }
 
-    function handle($match, $state, $pos, &$handler) {
+    function handle($match, $state, $pos, Doku_Handler $handler) {
         switch ($state) {
             case DOKU_LEXER_ENTER :      return array($state, '');
             case DOKU_LEXER_UNMATCHED :  return array($state, Markdown($match));
@@ -44,7 +44,7 @@ class syntax_plugin_markdownextra extends DokuWiki_Syntax_Plugin {
         return array($state,'');
     }
 
-    function render($mode, &$renderer, $data) {
+    function render($mode, Doku_Renderer $renderer, $data) {
         //dbg('function render($mode, &$renderer, $data)-->'.' mode = '.$mode.' data = '.$data);
         //dbg($data);
         if ($mode == 'xhtml') {


### PR DESCRIPTION
Starting with PHP 7, classes that overide methods from their parent have to match their parent's method signature regarding type hints. Otherwise PHP will throw an error.

Your plugin seems not to match DokuWiki's method signatures causing it to fail under PHP7. This patch tries to fix that.

Please note that this patch and the resulting pull request were created using an automated tool. Something might have gone, wrong so please carefully check before merging.

If you think the code submitted is wrong, please feel free to close this PR and excuse the mess.