### PR TITLE
do not exclude indexer.php in tests in wikitext preprocess

### DIFF
--- a/action.php
+++ b/action.php
@@ -26,11 +26,14 @@ class action_plugin_markdownextra extends DokuWiki_Action_Plugin {
        global $TEXT;
        // Check if file is a .md page:
        if(substr($ID,-3) != '.md') return true;
-       // Check for default view (in this case there is only 1 parsed text)
-       // or check that the text parsed is the text being edited
-       // (see: http://www.dokuwiki.org/devel:environment#text):
-       if($ACT != 'show' && $event->data != $TEXT) return true;
-       
+       if ($ACT !== null) { // $ACT === null case: e.g. indexer
+          // Check for default view (in this case there is only 1 parsed text)
+          // or check that the text parsed is the text being edited
+          // i.e. the save and preview case
+          // (see: http://www.dokuwiki.org/devel:environment#text):
+          if($ACT != 'show' && $event->data != $TEXT) return true;
+       }
+
        if ($this->getConf('frontmatter')){
            if (preg_match('/^---\s*\n(.*?\n?)^---\s*$\n?(.+)/sm',$event->data, $match)){
                $event->data = sprintf("%s<markdown>\n%s\n</markdown>", $match[1], $match[2]);


### PR DESCRIPTION
indexer.php(for search index) of dokuwiki and 'show' operation enter in a race condition. if the excluded indexer.php generates cache first, .md page will result in wrong rendered xhtml